### PR TITLE
fix: correct uv publish flag for TestPyPI

### DIFF
--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -103,7 +103,7 @@ Before publishing to the real PyPI, test on TestPyPI:
 
 ```bash
 # Upload to TestPyPI
-uv publish --index-url https://test.pypi.org/legacy/
+uv publish --publish-url https://test.pypi.org/legacy/
 ```
 
 You'll be prompted for your TestPyPI credentials or API token.


### PR DESCRIPTION
Change --index-url to --publish-url as per uv publish documentation. The correct flag for specifying the upload endpoint URL is --publish-url.

Fixes the command in step 6 of the release process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)