### PR TITLE
Remove extra storage round-trip in redirect path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove extra `default_storage.exists()` call from `ServeScormContentView` redirect path ([#44](https://github.com/dr-rompecabezas/wagtail-lms/issues/44))
+  - Eliminates ~50-100ms latency per media asset request in S3-backed deployments
+  - Missing files now produce a redirect to S3 (which returns 403/404) instead of a Django 404
+
 ### Fixed
 
 - Handle exceptions in `ServeScormContentView` redirect path ([#43](https://github.com/dr-rompecabezas/wagtail-lms/issues/43))

--- a/src/wagtail_lms/views.py
+++ b/src/wagtail_lms/views.py
@@ -412,8 +412,6 @@ class ServeScormContentView(LoginRequiredMixin, View):
         content_type = self.get_content_type(normalized)
 
         if self.should_redirect(content_type, storage_path):
-            if not default_storage.exists(storage_path):
-                raise Http404("File not found")
             try:
                 response = redirect(self.get_redirect_url(storage_path))
             except (Http404, PermissionDenied, SuspiciousOperation):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -484,8 +484,6 @@ class TestServeScormContent:
         monkeypatch.setattr(conf, "WAGTAIL_LMS_REDIRECT_MEDIA", True)
 
         relative_path = f"{scorm_package.extracted_path}/lesson.mp4"
-        storage_path = f"{conf.WAGTAIL_LMS_CONTENT_PATH.rstrip('/')}/{relative_path}"
-        default_storage.save(storage_path, ContentFile(b"fake-video"))
 
         class BrokenRedirectView(ServeScormContentView):
             def get_redirect_url(self, storage_path):
@@ -530,8 +528,6 @@ class TestServeScormContent:
         monkeypatch.setattr(conf, "WAGTAIL_LMS_REDIRECT_MEDIA", True)
 
         relative_path = f"{scorm_package.extracted_path}/lesson.mp4"
-        storage_path = f"{conf.WAGTAIL_LMS_CONTENT_PATH.rstrip('/')}/{relative_path}"
-        default_storage.save(storage_path, ContentFile(b"fake-video"))
 
         class GuardedRedirectView(ServeScormContentView):
             def get_redirect_url(self, path):


### PR DESCRIPTION
## Summary

- Removes `default_storage.exists()` call from `ServeScormContentView` redirect path, eliminating ~50-100ms latency per media asset request in S3-backed deployments
- Tests updated to reflect that the exists check is no longer performed before `get_redirect_url()`
- Changelog updated under `[Unreleased]`

Closes #44

## Trade-off

Missing files now produce a redirect to S3 (which returns 403/404) instead of a clean Django 404. In practice this is fine for `<video>` and `<audio>` elements which handle failed loads gracefully.

## Test plan

- [ ] All 88 existing tests pass
- [ ] `test_serve_scorm_content_redirects_media_when_enabled` still verifies the happy-path redirect
- [ ] `test_serve_scorm_content_redirect_url_error_returns_404` verifies failures in `get_redirect_url()` still return 404
- [ ] Parametrized Django exception propagation tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)