### PR TITLE
Remove deprecated serve_scorm_content wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-02-16
+
 ### Added
 
 - **Wagtail admin interface for SCORM packages, enrollments, and attempts** ([#52](https://github.com/dr-rompecabezas/wagtail-lms/issues/52))
@@ -21,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `SCORMPackageListView` and its template (`scorm_package_list.html`) — replaced by Wagtail's built-in viewset views
 - `/lms/scorm-packages/` URL endpoint — SCORM packages are now managed at `/admin/scormpackage/`
+- **Deprecated `serve_scorm_content` compatibility wrapper** ([#56](https://github.com/dr-rompecabezas/wagtail-lms/issues/56))
+  - Removed `serve_scorm_content()` function alias in `wagtail_lms.views`
+  - Removed one-time deprecation warning globals (`_serve_scorm_content_view`, `_serve_scorm_content_warned`)
+  - Removed deprecated-wrapper warning test (`test_serve_scorm_content_import_warning_emitted_once`)
 
 ## [0.7.0] - 2026-02-15
 

--- a/src/wagtail_lms/views.py
+++ b/src/wagtail_lms/views.py
@@ -2,7 +2,6 @@ import json
 import mimetypes
 import posixpath
 import time
-import warnings
 from datetime import datetime
 from functools import wraps
 
@@ -421,25 +420,3 @@ class ServeScormContentView(LoginRequiredMixin, View):
         self.apply_security_headers(response)
         self.apply_cache_header(response, content_type)
         return response
-
-
-_serve_scorm_content_view = ServeScormContentView.as_view()
-_serve_scorm_content_warned = False
-
-
-def serve_scorm_content(request, content_path, *args, **kwargs):
-    """Deprecated compatibility wrapper for old FBV imports."""
-    # TODO(0.8.0): Remove this function and the _serve_scorm_content_* module globals above.
-    global _serve_scorm_content_warned
-
-    if not _serve_scorm_content_warned:
-        warnings.warn(
-            "serve_scorm_content is deprecated as a direct import. "
-            "Use ServeScormContentView.as_view() instead. "
-            "This compatibility wrapper will be removed in 0.8.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        _serve_scorm_content_warned = True
-
-    return _serve_scorm_content_view(request, content_path, *args, **kwargs)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,6 @@
 """Tests for wagtail-lms views."""
 
 import json
-import warnings
 
 import pytest
 from django.core.files.base import ContentFile
@@ -655,28 +654,3 @@ class TestServeScormContent:
         )
         response = client.get(url)
         assert response.status_code == 404
-
-    def test_serve_scorm_content_import_warning_emitted_once(self, user, monkeypatch):
-        """Deprecated alias should emit a warning only once."""
-        from wagtail_lms import views as lms_views
-
-        monkeypatch.setattr(lms_views, "_serve_scorm_content_warned", False)
-
-        factory = RequestFactory()
-        request = factory.get("/")
-        request.user = user
-
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            with pytest.raises(Http404):
-                lms_views.serve_scorm_content(request, "/etc/passwd")
-            with pytest.raises(Http404):
-                lms_views.serve_scorm_content(request, "/etc/passwd")
-
-        deprecations = [
-            warning
-            for warning in caught
-            if issubclass(warning.category, DeprecationWarning)
-        ]
-        assert len(deprecations) == 1
-        assert "ServeScormContentView.as_view()" in str(deprecations[0].message)


### PR DESCRIPTION
This pull request removes the deprecated `serve_scorm_content` compatibility wrapper from the codebase, as planned for version 0.8.0. It also updates the changelog to reflect this deprecation and cleans up related tests and imports.

Deprecation cleanup:

* Removed the `serve_scorm_content()` function alias and associated deprecation warning globals (`_serve_scorm_content_view`, `_serve_scorm_content_warned`) from `wagtail_lms.views.py`.
* Deleted the deprecated-wrapper warning test (`test_serve_scorm_content_import_warning_emitted_once`) from `tests/test_views.py`.
* Removed unnecessary `warnings` import from both `wagtail_lms.views.py` and `tests/test_views.py`. [[1]](diffhunk://#diff-2aebf7b3386f3f4b75b47172d544de270bf16bbc3f70253333c9f30c1f3d092cL5) [[2]](diffhunk://#diff-bbc49e4202aabab5bb86711f4824030832a25188901ab84ab72e7e550b66603cL4)

Documentation update:

* Added a changelog entry for version 0.8.0, documenting the removal of the deprecated `serve_scorm_content` wrapper and related globals/tests. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R11) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR26-R29)