### PR TITLE
Renamed `WAGTAIL_LMS_CONTENT_PATH`  to `WAGTAIL_LMS_SCORM_CONTENT_PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Deprecated
+
+- `WAGTAIL_LMS_CONTENT_PATH` renamed to `WAGTAIL_LMS_SCORM_CONTENT_PATH` for consistency with the `WAGTAIL_LMS_SCORM_*` prefix convention. The old name still works and its configured value is honoured, but it now emits a `DeprecationWarning` at startup. It will be removed in a future release — rename the setting in your Django settings to silence the warning.
+
 ## [0.9.0] - 2026-02-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Optional settings in your Django settings:
 ```python
 # SCORM
 WAGTAIL_LMS_SCORM_UPLOAD_PATH = 'scorm_packages/'  # Upload directory
-WAGTAIL_LMS_CONTENT_PATH = 'scorm_content/'        # Extracted content
+WAGTAIL_LMS_SCORM_CONTENT_PATH = 'scorm_content/'        # Extracted content
 WAGTAIL_LMS_AUTO_ENROLL = False                     # Auto-enroll on course visit
 
 # H5P

--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -168,7 +168,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # Wagtail LMS settings (optional — defaults shown)
 # SCORM
 # WAGTAIL_LMS_SCORM_UPLOAD_PATH = 'scorm_packages/'
-# WAGTAIL_LMS_CONTENT_PATH = 'scorm_content/'
+# WAGTAIL_LMS_SCORM_CONTENT_PATH = 'scorm_content/'
 # WAGTAIL_LMS_AUTO_ENROLL = False
 # WAGTAIL_LMS_CACHE_CONTROL = {
 #     "text/html": "no-cache",

--- a/src/wagtail_lms/conf.py
+++ b/src/wagtail_lms/conf.py
@@ -1,14 +1,8 @@
 """Default settings for wagtail-lms"""
 
+import warnings
+
 from django.conf import settings
-
-WAGTAIL_LMS_SCORM_UPLOAD_PATH = getattr(
-    settings, "WAGTAIL_LMS_SCORM_UPLOAD_PATH", "scorm_packages/"
-)
-
-WAGTAIL_LMS_CONTENT_PATH = getattr(
-    settings, "WAGTAIL_LMS_CONTENT_PATH", "scorm_content/"
-)
 
 WAGTAIL_LMS_AUTO_ENROLL = getattr(settings, "WAGTAIL_LMS_AUTO_ENROLL", False)
 
@@ -27,6 +21,34 @@ WAGTAIL_LMS_CACHE_CONTROL = getattr(
 )
 
 WAGTAIL_LMS_REDIRECT_MEDIA = getattr(settings, "WAGTAIL_LMS_REDIRECT_MEDIA", False)
+
+WAGTAIL_LMS_SCORM_UPLOAD_PATH = getattr(
+    settings, "WAGTAIL_LMS_SCORM_UPLOAD_PATH", "scorm_packages/"
+)
+
+_old_scorm_content_path = getattr(settings, "WAGTAIL_LMS_CONTENT_PATH", None)
+_new_scorm_content_path = getattr(settings, "WAGTAIL_LMS_SCORM_CONTENT_PATH", None)
+
+if _old_scorm_content_path is not None and _new_scorm_content_path is None:
+    warnings.warn(
+        "WAGTAIL_LMS_CONTENT_PATH is deprecated and will be removed in a future version. "
+        "Rename it to WAGTAIL_LMS_SCORM_CONTENT_PATH in your Django settings.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+WAGTAIL_LMS_SCORM_CONTENT_PATH = (
+    _new_scorm_content_path
+    if _new_scorm_content_path is not None
+    else (
+        _old_scorm_content_path
+        if _old_scorm_content_path is not None
+        else "scorm_content/"
+    )
+)
+
+# Keep the old name accessible for any downstream code that imports it from conf directly.
+WAGTAIL_LMS_CONTENT_PATH = WAGTAIL_LMS_SCORM_CONTENT_PATH
 
 WAGTAIL_LMS_H5P_UPLOAD_PATH = getattr(
     settings, "WAGTAIL_LMS_H5P_UPLOAD_PATH", "h5p_packages/"

--- a/src/wagtail_lms/models.py
+++ b/src/wagtail_lms/models.py
@@ -81,7 +81,7 @@ class SCORMPackage(models.Model):
         # Create extraction directory with unique path using package ID
         package_name = os.path.splitext(os.path.basename(self.package_file.name))[0]
         unique_dir = f"package_{self.id}_{package_name}"
-        content_path = conf.WAGTAIL_LMS_CONTENT_PATH.rstrip("/")
+        content_path = conf.WAGTAIL_LMS_SCORM_CONTENT_PATH.rstrip("/")
 
         manifest_content = None
 

--- a/src/wagtail_lms/signal_handlers.py
+++ b/src/wagtail_lms/signal_handlers.py
@@ -47,7 +47,7 @@ def _delete_extracted_content(extracted_path, content_base_path):
 
     Args:
         extracted_path: The relative extracted directory name (e.g. 'package_1_foo').
-        content_base_path: The configured base path (e.g. conf.WAGTAIL_LMS_CONTENT_PATH).
+        content_base_path: The configured base path (e.g. conf.WAGTAIL_LMS_SCORM_CONTENT_PATH).
     """
     normalized = posixpath.normpath(extracted_path)
     # Reject anything that isn't a single, plain directory name:
@@ -85,7 +85,9 @@ def post_delete_scorm_cleanup(sender, instance, **kwargs):
 
         if extracted_path:
             try:
-                _delete_extracted_content(extracted_path, conf.WAGTAIL_LMS_CONTENT_PATH)
+                _delete_extracted_content(
+                    extracted_path, conf.WAGTAIL_LMS_SCORM_CONTENT_PATH
+                )
             except Exception:
                 logger.exception(
                     "Failed to delete extracted SCORM content: %s", extracted_path

--- a/src/wagtail_lms/views.py
+++ b/src/wagtail_lms/views.py
@@ -484,7 +484,7 @@ class ServeScormContentView(LoginRequiredMixin, View):
         return normalized
 
     def get_storage_path(self, normalized_content_path):
-        content_base = conf.WAGTAIL_LMS_CONTENT_PATH.rstrip("/")
+        content_base = conf.WAGTAIL_LMS_SCORM_CONTENT_PATH.rstrip("/")
         return posixpath.join(content_base, normalized_content_path)
 
     def get_content_type(self, content_path):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -382,7 +382,7 @@ class TestSCORMPackageStorageBackend:
 
     def test_extract_uses_storage_api(self, scorm_package):
         """Verify extracted files are accessible via default_storage."""
-        content_path = conf.WAGTAIL_LMS_CONTENT_PATH.rstrip("/")
+        content_path = conf.WAGTAIL_LMS_SCORM_CONTENT_PATH.rstrip("/")
         storage_path = f"{content_path}/{scorm_package.extracted_path}/index.html"
         assert default_storage.exists(storage_path)
 
@@ -395,7 +395,7 @@ class TestSCORMPackageStorageBackend:
         package.save()
 
         assert package.extracted_path != ""
-        content_path = conf.WAGTAIL_LMS_CONTENT_PATH.rstrip("/")
+        content_path = conf.WAGTAIL_LMS_SCORM_CONTENT_PATH.rstrip("/")
         storage_path = f"{content_path}/{package.extracted_path}/index.html"
         assert default_storage.exists(storage_path)
         assert package.launch_url == "index.html"
@@ -414,7 +414,7 @@ class TestSCORMPackageStorageBackend:
         package.save()
 
         # Safe files should be extracted
-        content_path = conf.WAGTAIL_LMS_CONTENT_PATH.rstrip("/")
+        content_path = conf.WAGTAIL_LMS_SCORM_CONTENT_PATH.rstrip("/")
         safe_path = f"{content_path}/{package.extracted_path}/index.html"
         assert default_storage.exists(safe_path)
 

--- a/tests/test_signal_handlers.py
+++ b/tests/test_signal_handlers.py
@@ -29,7 +29,7 @@ def _make_scorm_zip(manifest_xml, content_filename="index.html"):
 
 def _content_prefix(extracted_path):
     """Build the storage prefix for extracted content using the configured path."""
-    return conf.WAGTAIL_LMS_CONTENT_PATH.rstrip("/") + "/" + extracted_path
+    return conf.WAGTAIL_LMS_SCORM_CONTENT_PATH.rstrip("/") + "/" + extracted_path
 
 
 def _make_h5p_zip():
@@ -191,7 +191,7 @@ class TestSCORMPackageDeletion:
     def test_path_traversal_rejected(self, bad_path):
         """Suspicious extracted_path values are refused without touching storage."""
         with patch("wagtail_lms.signal_handlers.default_storage") as mock_storage:
-            _delete_extracted_content(bad_path, conf.WAGTAIL_LMS_CONTENT_PATH)
+            _delete_extracted_content(bad_path, conf.WAGTAIL_LMS_SCORM_CONTENT_PATH)
             mock_storage.listdir.assert_not_called()
             mock_storage.delete.assert_not_called()
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -494,7 +494,9 @@ class TestServeScormContent:
         client.force_login(user)
 
         relative_path = f"{scorm_package.extracted_path}/logo.png"
-        storage_path = f"{conf.WAGTAIL_LMS_CONTENT_PATH.rstrip('/')}/{relative_path}"
+        storage_path = (
+            f"{conf.WAGTAIL_LMS_SCORM_CONTENT_PATH.rstrip('/')}/{relative_path}"
+        )
         default_storage.save(storage_path, ContentFile(b"fake-image"))
 
         url = reverse("wagtail_lms:serve_scorm_content", args=[relative_path])
@@ -534,7 +536,9 @@ class TestServeScormContent:
         monkeypatch.setattr(conf, "WAGTAIL_LMS_REDIRECT_MEDIA", True)
 
         relative_path = f"{scorm_package.extracted_path}/lesson.mp4"
-        storage_path = f"{conf.WAGTAIL_LMS_CONTENT_PATH.rstrip('/')}/{relative_path}"
+        storage_path = (
+            f"{conf.WAGTAIL_LMS_SCORM_CONTENT_PATH.rstrip('/')}/{relative_path}"
+        )
         default_storage.save(storage_path, ContentFile(b"fake-video"))
 
         url = reverse("wagtail_lms:serve_scorm_content", args=[relative_path])


### PR DESCRIPTION
This pull request standardizes the naming of the SCORM content path setting for improved clarity and consistency. The setting previously known as `WAGTAIL_LMS_CONTENT_PATH` has been renamed to `WAGTAIL_LMS_SCORM_CONTENT_PATH`, with the old name deprecated but still supported for backward compatibility (a warning will be issued if used). All references throughout the codebase, documentation, and tests have been updated to use the new name.

**Deprecation and Backward Compatibility:**
- The `WAGTAIL_LMS_CONTENT_PATH` setting is now deprecated in favor of `WAGTAIL_LMS_SCORM_CONTENT_PATH`. Using the old name emits a `DeprecationWarning`, but its value is still honored for backward compatibility. The old name is still accessible in `conf.py` for downstream code. [[1]](diffhunk://#diff-64572f23f38b0dc2dd08ff6935ec258c47ac0194b05bb13c792e1f8da9d93205R25-R46) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13)

**Codebase Updates:**
- All internal references in the codebase have been updated to use `WAGTAIL_LMS_SCORM_CONTENT_PATH` instead of the deprecated `WAGTAIL_LMS_CONTENT_PATH`, including in model methods, signal handlers, and views. [[1]](diffhunk://#diff-5836c5a964df42606a41d0adbc7669505603417ec30649f8384e990eb7b69cddL84-R84) [[2]](diffhunk://#diff-79e2cf9fc545eddf4253492133284b219985e9f8a6d69f79c81dfe9085907a3cL50-R50) [[3]](diffhunk://#diff-79e2cf9fc545eddf4253492133284b219985e9f8a6d69f79c81dfe9085907a3cL88-R90) [[4]](diffhunk://#diff-2aebf7b3386f3f4b75b47172d544de270bf16bbc3f70253333c9f30c1f3d092cL487-R487)

**Documentation Updates:**
- The documentation in `README.md`, `CHANGELOG.md`, and example settings has been updated to reference `WAGTAIL_LMS_SCORM_CONTENT_PATH`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L86-R86) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13) [[3]](diffhunk://#diff-b03989168c0e7cb33cb15bd430e7e93ab1549ba0bba617d7ed5dc4907a03cac4L171-R171)

**Test Suite Updates:**
- All test code has been updated to use the new setting name, ensuring consistency and preventing deprecation warnings during test runs. [[1]](diffhunk://#diff-0adb667cd397bd56edce10eec11e1b10821740a10d72bd148b09645fc9108968L385-R385) [[2]](diffhunk://#diff-0adb667cd397bd56edce10eec11e1b10821740a10d72bd148b09645fc9108968L398-R398) [[3]](diffhunk://#diff-0adb667cd397bd56edce10eec11e1b10821740a10d72bd148b09645fc9108968L417-R417) [[4]](diffhunk://#diff-12d1edc23f22b7a78003d57c53a6f79ac7c14e38eed0902ac52172bde01a29e7L32-R32) [[5]](diffhunk://#diff-12d1edc23f22b7a78003d57c53a6f79ac7c14e38eed0902ac52172bde01a29e7L194-R194) [[6]](diffhunk://#diff-bbc49e4202aabab5bb86711f4824030832a25188901ab84ab72e7e550b66603cL497-R499) [[7]](diffhunk://#diff-bbc49e4202aabab5bb86711f4824030832a25188901ab84ab72e7e550b66603cL537-R541)